### PR TITLE
gud: EDID and mode object fixes

### DIFF
--- a/examples/pico-display/pico-display.c
+++ b/examples/pico-display/pico-display.c
@@ -273,6 +273,9 @@ static const struct gud_display_edid edid = {
     .width_mm = 27,
     .height_mm = 16,
 
+    .gamma = 220,
+    .bit_depth = 6,
+
     .get_serial_number = gud_display_edid_get_serial_number,
 };
 

--- a/libraries/gud_pico/gud.c
+++ b/libraries/gud_pico/gud.c
@@ -187,7 +187,7 @@ static int gud_req_get_connector_edid(const struct gud_display *disp,
     }
 
     // Manufacture
-    edid[16] = 1; // week
+    edid[16] = disp->edid->week;
     if (disp->edid->year > 1990)
         edid[17] = disp->edid->year - 1990;
     else

--- a/libraries/gud_pico/gud.c
+++ b/libraries/gud_pico/gud.c
@@ -201,11 +201,12 @@ static int gud_req_get_connector_edid(const struct gud_display *disp,
     edid[21] = div_round_up(disp->edid->width_mm, 10); // width in cm
     edid[22] = div_round_up(disp->edid->height_mm, 10); // height in cm
     edid[23] = 0; // gamma
-    edid[24] = 0x0a; // RGB-color, preferred timing in DTD 1
+    edid[24] = 0x02; // RGB 4:4:4, preferred timings include pixel format and refresh rate
 
     // Chromaticity coordinates, required for sRGB
     struct gud_display_chromaticity *chroma = disp->edid->chromaticity;
     if (chroma == NULL) {
+        edid[24] |= 0x4; // Standard sRGB color space
         chroma = &default_chromaticity;
     }
     // Red and green 2 least significant bits

--- a/libraries/gud_pico/gud.c
+++ b/libraries/gud_pico/gud.c
@@ -200,7 +200,7 @@ static int gud_req_get_connector_edid(const struct gud_display *disp,
     edid[20] = 0x80;  // Digital input: 1, bit depth: undefined, interface: undefined
     edid[21] = div_round_up(disp->edid->width_mm, 10); // width in cm
     edid[22] = div_round_up(disp->edid->height_mm, 10); // height in cm
-    edid[23] = 0; // gamma
+    edid[23] = disp->edid->gamma ? disp->edid->gamma - 100 : 0; // gamma
     edid[24] = 0x02; // RGB 4:4:4, preferred timings include pixel format and refresh rate
 
     // Chromaticity coordinates, required for sRGB

--- a/libraries/gud_pico/gud.c
+++ b/libraries/gud_pico/gud.c
@@ -193,8 +193,8 @@ static int gud_req_get_connector_edid(const struct gud_display *disp,
     else
         edid[17] = 0;
 
-    // EDID version 1.3
-    edid[18] = 1; edid[19] = 3;
+    // EDID version 1.4
+    edid[18] = 1; edid[19] = 4;
 
     // Basic display parameters
     edid[20] = 0x80;  // Digital input: 1, bit depth: undefined, interface: undefined

--- a/libraries/gud_pico/gud.c
+++ b/libraries/gud_pico/gud.c
@@ -197,7 +197,27 @@ static int gud_req_get_connector_edid(const struct gud_display *disp,
     edid[18] = 1; edid[19] = 4;
 
     // Basic display parameters
-    edid[20] = 0x80;  // Digital input: 1, bit depth: undefined, interface: undefined
+    edid[20] = 0x80; // Digital input: 1, interface: undefined
+    switch (disp->edid->bit_depth) {
+    case 16:
+        edid[20] |= 0b110 << 4;
+        break;
+    case 14:
+        edid[20] |= 0b101 << 4;
+        break;
+    case 12:
+        edid[20] |= 0b100 << 4;
+        break;
+    case 10:
+        edid[20] |= 0b011 << 4;
+        break;
+    case 8:
+        edid[20] |= 0b010 << 4;
+        break;
+    case 6:
+        edid[20] |= 0b001 << 4;
+        break;
+    }
     edid[21] = div_round_up(disp->edid->width_mm, 10); // width in cm
     edid[22] = div_round_up(disp->edid->height_mm, 10); // height in cm
     edid[23] = disp->edid->gamma ? disp->edid->gamma - 100 : 0; // gamma

--- a/libraries/gud_pico/gud.h
+++ b/libraries/gud_pico/gud.h
@@ -360,6 +360,7 @@ struct gud_display_edid {
 	const char *name;	// Max 13 characters
 	const char *pnp;	// Plug'n Play Id, must be 3 uppercase characters
 	uint16_t product_code;
+	uint8_t week;
 	uint16_t year;
 	uint16_t width_mm;
 	uint16_t height_mm;

--- a/libraries/gud_pico/gud.h
+++ b/libraries/gud_pico/gud.h
@@ -336,6 +336,14 @@ struct gud_state_req {
 /* Enable/disable display/output (DPMS), value is u8: 0/1 */
 #define GUD_REQ_SET_DISPLAY_ENABLE			0x64
 
+struct gud_color_xy {
+	uint16_t x, y;
+};
+
+struct gud_display_chromaticity {
+	struct gud_color_xy r, g, b, w;
+};
+
 struct gud_display_edid {
 	const char *name;	// Max 13 characters
 	const char *pnp;	// Plug'n Play Id, must be 3 uppercase characters
@@ -343,6 +351,8 @@ struct gud_display_edid {
 	uint16_t year;
 	uint16_t width_mm;
 	uint16_t height_mm;
+
+	struct gud_display_chromaticity *chromaticity;
 
 	uint32_t (*get_serial_number)(void);
 };

--- a/libraries/gud_pico/gud.h
+++ b/libraries/gud_pico/gud.h
@@ -363,6 +363,7 @@ struct gud_display_edid {
 	uint16_t year;
 	uint16_t width_mm;
 	uint16_t height_mm;
+	uint16_t gamma;
 
 	struct gud_display_chromaticity *chromaticity;
 	struct gud_display_timings *timings;

--- a/libraries/gud_pico/gud.h
+++ b/libraries/gud_pico/gud.h
@@ -363,6 +363,7 @@ struct gud_display_edid {
 	uint16_t year;
 	uint16_t width_mm;
 	uint16_t height_mm;
+	uint8_t bit_depth;
 	uint16_t gamma;
 
 	struct gud_display_chromaticity *chromaticity;

--- a/libraries/gud_pico/gud.h
+++ b/libraries/gud_pico/gud.h
@@ -344,6 +344,18 @@ struct gud_display_chromaticity {
 	struct gud_color_xy r, g, b, w;
 };
 
+struct gud_display_timings {
+	uint8_t hfront;
+	uint8_t hsync;
+	uint8_t hback;
+
+	uint8_t vfront;
+	uint8_t vsync;
+	uint8_t vback;
+
+	uint8_t framerate;
+};
+
 struct gud_display_edid {
 	const char *name;	// Max 13 characters
 	const char *pnp;	// Plug'n Play Id, must be 3 uppercase characters
@@ -353,6 +365,7 @@ struct gud_display_edid {
 	uint16_t height_mm;
 
 	struct gud_display_chromaticity *chromaticity;
+	struct gud_display_timings *timings;
 
 	uint32_t (*get_serial_number)(void);
 };


### PR DESCRIPTION
The currently reported EDID fails validation, and does not match the mode object. The mode object on the other hand reports a pixel clock of 1, leading to a reported preferred refresh rate of 13mHz for my test.

Unify timing handling, fix the EDID validity by adding chromaticity and fixing up pixel format reporting, and add a few missing fields while at it. See the individual commits.