### PR TITLE
gud: Fix connector mode framerate

### DIFF
--- a/libraries/gud_pico/gud.c
+++ b/libraries/gud_pico/gud.c
@@ -144,7 +144,7 @@ static int gud_req_get_connector_modes(const struct gud_display *disp, struct gu
     mode->vsync_start = mode->vdisplay + timings->vfront;
     mode->vsync_end = mode->vsync_start + timings->vsync;
     mode->vtotal = mode->vsync_end + timings->vback;
-    mode->clock = mode->htotal * mode->vtotal * timings->framerate;
+    mode->clock = div_round_up(mode->htotal * mode->vtotal * timings->framerate, 1000);
     mode->flags = GUD_DISPLAY_MODE_FLAG_PREFERRED;
 
     return sizeof(*mode);


### PR DESCRIPTION
The pixel clock calculation introduced by d3f2bac902cd ("gud: Centralize timing data") forgot a crucial divide by 1000, leading to drm_info reporting 60000 Hz instead of 60 Hz.

Divide the clock by thousand so that modes reported by drm_info matches those reported by the edid.